### PR TITLE
Make Element Emit "Input" Event When Switch Changes State

### DIFF
--- a/src/javascript/Switch.js
+++ b/src/javascript/Switch.js
@@ -175,10 +175,21 @@ export class Switch {
      */
     syncState() {
         this.element.checked = this.checked;
+        this.dispatchEvent();
+    }
 
-        // dispatch change event
-        const evt = new Event("change");
-        this.element.dispatchEvent(evt);
+    /**
+     * Dispatches relevant events for the element changing, trying to emulate
+     * natural <input> elements as much as possible.
+     * @private
+     */
+    dispatchEvent() {
+        // https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event
+        const changeEvent = new Event("change");
+        this.element.dispatchEvent(changeEvent);
+        // https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event
+        const inputEvent = new Event("input");
+        this.element.dispatchEvent(inputEvent);
     }
 
     handleTrackClick(e) {

--- a/test/basic.html
+++ b/test/basic.html
@@ -19,7 +19,10 @@
     <body>
         <div class="switch-wrapper">
             <label>
-                <input type="checkbox" data-type="simple-switch" />
+                <input
+                    type="checkbox"
+                    data-type="simple-switch"
+                    id="testCheckbox" />
                 Remember Me
             </label>
         </div>
@@ -30,9 +33,39 @@
                 Sign Up for Newsletter
             </label>
         </div>
+        <div class="switch-wrapper">
+          <label>
+              <input
+                  type="checkbox"
+                  data-type="simple-switch"
+                  disabled
+                  checked />
+              Disabled
+          </label>
+      </div>
+        <div class="switch-wrapper">
+          <label>
+              <input
+                  type="checkbox"
+                  data-type="simple-switch"
+                  data-material="true"
+                  disabled
+                  checked />
+              Disabled (Material)
+          </label>
+      </div>
         <script type="text/javascript" src="/dist/js/SimpleSwitch.min.js"></script>
         <script type="text/javascript">
             SimpleSwitch.init();
+            const testCheckbox = document.getElementById("testCheckbox");
+            testCheckbox.addEventListener("input", (e) => {
+              console.log("input event");
+              console.log(e);
+            });
+            testCheckbox.addEventListener("change", (e) => {
+              console.log("change event");
+              console.log(e);
+            });
         </script>
     </body>
 </html>


### PR DESCRIPTION
As requested in #15, makes the element also emit the `input` event ([docs](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event)) when it changes state. This brings this component more in line with native HTML elements.

Closes #15 