### PR TITLE
Remove deprecated SASS functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "a-simple-switch",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "a-simple-switch",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "ISC",
       "devDependencies": {
         "@babel/core": "^7.26.0",

--- a/src/sass/SimpleSwitch.scss
+++ b/src/sass/SimpleSwitch.scss
@@ -12,152 +12,152 @@ $simple-switch-disable-color: color-mix(in srgb, $simple-switch_color 70%, white
 
 // Hide the checkbox, but keep it in the DOM so it is visible to screen readers
 ._simple-switch-checkbox {
-    height: 0px;
-    width: 0px;
-    overflow: hidden;
-    opacity: 0;
+  height: 0px;
+  width: 0px;
+  overflow: hidden;
+  opacity: 0;
 }
 
 ._simple-switch-track {
-    --simple-switch_size: #{$simple-switch_size};
+  --simple-switch_size: #{$simple-switch_size};
 
-    font-size: inherit;
-    display: inline-block;
+  font-size: inherit;
+  display: inline-block;
+  position: relative;
+  vertical-align: baseline;
+  background: $simple-switch_tray-color;
+  border-radius: $simple-switch_size;
+  padding: 0 calc((#{$simple-switch_size} * 1.25) - #{$simple-switch_outline-size * 2}) 0 0;
+  border: #{$simple-switch_outline-size} solid $simple-switch_tray-color;
+  transition: background $simple-switch_switch-speed ease-out,
+              border $simple-switch_switch-speed ease-out;
+  outline: none;
+  box-sizing: padding-box;
+
+  @supports(--foobar: false) {
+    border-radius: var(--simple-switch_size);
+    padding: 0 calc((var(--simple-switch_size) * 1.25) - #{$simple-switch_outline-size * 2}) 0 0;
+  }
+
+  &.on {
+    background: $simple-switch_color;
+    border: #{$simple-switch_outline-size} solid $simple-switch_color;
+
+    .handle {
+      transform: translateX(calc((#{$simple-switch_size} * 1.25) - #{$simple-switch_outline-size * 2}));
+
+      @supports(--foobar: false) {
+        transform: translateX(calc((var(--simple-switch_size) * 1.25) - #{$simple-switch_outline-size * 2}));
+      }
+    }
+  }
+
+  &.focus {
+    border: #{$simple-switch_outline-size} solid $simple-switch_focus-color;
+  }
+
+  .handle {
     position: relative;
-    vertical-align: baseline;
-    background: $simple-switch_tray-color;
+    width: calc(#{$simple-switch_size - ($simple-switch_outline-size * 2)});
+    height: calc(#{$simple-switch_size - ($simple-switch_outline-size * 2)});
     border-radius: $simple-switch_size;
-    padding: 0 calc((#{$simple-switch_size} * 1.25) - #{$simple-switch_outline-size * 2}) 0 0;
-    border: #{$simple-switch_outline-size} solid $simple-switch_tray-color;
-    transition: background $simple-switch_switch-speed ease-out,
-                border $simple-switch_switch-speed ease-out;
-    outline: none;
-    box-sizing: padding-box;
+    background: $simple-switch_handle-color;
+    display: block;
+    transition: transform $simple-switch_switch-speed ease-out;
+    will-change: transition;
+    z-index: 2;
 
     @supports(--foobar: false) {
-        border-radius: var(--simple-switch_size);
-        padding: 0 calc((var(--simple-switch_size) * 1.25) - #{$simple-switch_outline-size * 2}) 0 0;
+      width: calc(var(--simple-switch_size) - #{$simple-switch_outline-size * 2});
+      height: calc(var(--simple-switch_size) - #{$simple-switch_outline-size * 2});
+      border-radius: var(--simple-switch_size);
+    }
+  }
+
+  &._simple-switch_disabled {
+    background-color: $simple-switch_disable-color;
+    border-color: $simple-switch_disable-color;
+    cursor: default;
+  }
+
+  // Material mode (makes the Switch match the material.io spec)
+  &._material {
+    padding: 0;
+    margin: $simple-switch_outline-size 0;
+    height: #{$simple-switch_size - $simple-switch_outline-size};
+    width: #{$simple-switch_size * 1.5};
+    border: none;
+    vertical-align: top;
+
+    @supports(--foobar: false) {
+      height: calc(var(--simple-switch_size) - #{$simple-switch_outline-size});
+      width: calc(var(--simple-switch_size) * 1.5);
     }
 
     &.on {
-        background: $simple-switch_color;
-        border: #{$simple-switch_outline-size} solid $simple-switch_color;
+      background: $simple-switch_color;
 
-        .handle {
-            transform: translateX(calc((#{$simple-switch_size} * 1.25) - #{$simple-switch_outline-size * 2}));
+      &:after {
+        transform: translateX(#{$simple-switch_size - $simple-switch_outline-size});
 
-            @supports(--foobar: false) {
-                transform: translateX(calc((var(--simple-switch_size) * 1.25) - #{$simple-switch_outline-size * 2}));
-            }
+        @supports(--foobar: false) {
+          transform: translateX(calc(var(--simple-switch_size) - #{$simple-switch_outline-size}));
         }
+      }
+
+      .handle {
+        background: color-mix(in srgb, $simple-switch_color 85%, black);
+        transform: translateX(#{$simple-switch_size - $simple-switch_outline-size});
+
+        @supports(--foobar: false) {
+          transform: translateX(calc(var(--simple-switch_size) - #{$simple-switch_outline-size}));
+        }
+      }
     }
 
-    &.focus {
-        border: #{$simple-switch_outline-size} solid $simple-switch_focus-color;
+    // this represents the focus state ring
+    &:after {
+      $_extra: $simple-switch_focus-ring-size;
+
+      content: "";
+      position: absolute;
+      top: #{(-0.75 * $simple-switch_outline-size) - $_extra};
+      left: #{(-1 * $simple-switch_outline-size) - $_extra};
+      width: ($simple-switch_size + ($_extra * 2));
+      height: ($simple-switch_size + ($_extra * 2));
+      z-index: 1;
+      background: rgba(0, 0, 0, 0.125);
+      border-radius: ($simple-switch_size + ($_extra * 2));
+      opacity: 0;
+      will-change: opacity;
+      transition: opacity $simple-switch_switch-speed ease-out,
+                  transform $simple-switch_switch-speed ease-out;
+
+      @supports(--foobar: false) {
+        width: calc(var(--simple-switch_size) + #{$_extra * 2});
+        height: calc(var(--simple-switch_size) + #{$_extra * 2});
+        border-radius: calc(var(--simple-switch_size) + #{$_extra * 2});
+      }
+    }
+
+    &.focus:after {
+      opacity: 1;
     }
 
     .handle {
-        position: relative;
-        width: calc(#{$simple-switch_size - ($simple-switch_outline-size * 2)});
-        height: calc(#{$simple-switch_size - ($simple-switch_outline-size * 2)});
-        border-radius: $simple-switch_size;
-        background: $simple-switch_handle-color;
-        display: block;
-        transition: transform $simple-switch_switch-speed ease-out;
-        will-change: transition;
-        z-index: 2;
+      position: absolute;
+      top: #{-0.75 * $simple-switch_outline-size};
+      left: #{-1 * $simple-switch_outline-size};
+      width: $simple-switch_size;
+      height: $simple-switch_size;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+      transition: transform $simple-switch_switch-speed ease-out,
+                  background $simple-switch_switch-speed ease-out;
 
-        @supports(--foobar: false) {
-            width: calc(var(--simple-switch_size) - #{$simple-switch_outline-size * 2});
-            height: calc(var(--simple-switch_size) - #{$simple-switch_outline-size * 2});
-            border-radius: var(--simple-switch_size);
-        }
+      @supports(--foobar: false) {
+        width: var(--simple-switch_size);
+        height: var(--simple-switch_size);
+      }
     }
-
-    &._simple-switch_disabled {
-        background-color: $simple-switch_disable-color;
-        border-color: $simple-switch_disable-color;
-        cursor: default;
-    }
-
-    // Material mode (makes the Switch match the material.io spec)
-    &._material {
-        padding: 0;
-        margin: $simple-switch_outline-size 0;
-        height: #{$simple-switch_size - $simple-switch_outline-size};
-        width: #{$simple-switch_size * 1.5};
-        border: none;
-        vertical-align: top;
-
-        @supports(--foobar: false) {
-            height: calc(var(--simple-switch_size) - #{$simple-switch_outline-size});
-            width: calc(var(--simple-switch_size) * 1.5);
-        }
-
-        &.on {
-            background: $simple-switch_color;
-
-            &:after {
-                transform: translateX(#{$simple-switch_size - $simple-switch_outline-size});
-
-                @supports(--foobar: false) {
-                    transform: translateX(calc(var(--simple-switch_size) - #{$simple-switch_outline-size}));
-                }
-            }
-
-            .handle {
-                background: color-mix(in srgb, $simple-switch_color 85%, black);
-                transform: translateX(#{$simple-switch_size - $simple-switch_outline-size});
-
-                @supports(--foobar: false) {
-                    transform: translateX(calc(var(--simple-switch_size) - #{$simple-switch_outline-size}));
-                }
-            }
-        }
-
-        // this represents the focus state ring
-        &:after {
-            $_extra: $simple-switch_focus-ring-size;
-
-            content: "";
-            position: absolute;
-            top: #{(-0.75 * $simple-switch_outline-size) - $_extra};
-            left: #{(-1 * $simple-switch_outline-size) - $_extra};
-            width: ($simple-switch_size + ($_extra * 2));
-            height: ($simple-switch_size + ($_extra * 2));
-            z-index: 1;
-            background: rgba(0, 0, 0, 0.125);
-            border-radius: ($simple-switch_size + ($_extra * 2));
-            opacity: 0;
-            will-change: opacity;
-            transition: opacity $simple-switch_switch-speed ease-out,
-                        transform $simple-switch_switch-speed ease-out;
-
-            @supports(--foobar: false) {
-                width: calc(var(--simple-switch_size) + #{$_extra * 2});
-                height: calc(var(--simple-switch_size) + #{$_extra * 2});
-                border-radius: calc(var(--simple-switch_size) + #{$_extra * 2});
-            }
-        }
-
-        &.focus:after {
-            opacity: 1;
-        }
-
-        .handle {
-            position: absolute;
-            top: #{-0.75 * $simple-switch_outline-size};
-            left: #{-1 * $simple-switch_outline-size};
-            width: $simple-switch_size;
-            height: $simple-switch_size;
-            box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
-            transition: transform $simple-switch_switch-speed ease-out,
-                        background $simple-switch_switch-speed ease-out;
-
-            @supports(--foobar: false) {
-                width: var(--simple-switch_size);
-                height: var(--simple-switch_size);
-            }
-        }
-    }
+  }
 }

--- a/src/sass/SimpleSwitch.scss
+++ b/src/sass/SimpleSwitch.scss
@@ -7,7 +7,7 @@ $simple-switch_outline-size: 3px !default;
 $simple-switch_size: 18px !default;
 $simple-switch_switch-speed: 250ms !default;
 $simple-switch_tray-color: #ccc !default;
-$simple-switch-disable-color: lighten($simple-switch_color, 30%) !default;
+$simple-switch-disable-color: color-mix(in srgb, $simple-switch_color 70%, white) !default;
 
 
 // Hide the checkbox, but keep it in the DOM so it is visible to screen readers
@@ -106,7 +106,7 @@ $simple-switch-disable-color: lighten($simple-switch_color, 30%) !default;
             }
 
             .handle {
-                background: darken($simple-switch_color, 15%);
+                background: color-mix(in srgb, $simple-switch_color 85%, black);
                 transform: translateX(#{$simple-switch_size - $simple-switch_outline-size});
 
                 @supports(--foobar: false) {


### PR DESCRIPTION
Removes the deprecated SASS functions `darken()` and `lighten()` and replaces them with the CSS-standard `color-mix()` function instead.

There's a lot of spots where I could probably lean on CSS custom properties more here, especially given their near-universal support, but I want to do this incrementally and support anyone using the SASS variables.

Fixes #30 