### PR TITLE
Try 3rd party package for renaming package files

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,9 +39,13 @@ jobs:
           node-version: '20.x'
           registry-url: 'https://npm.pkg.github.com'
 
+      - name: Swap package name
+        uses: jaywcjlove/github-action-package@v2.0.0
+        with:
+          rename: '@ava-cassiopeia/a-simple-switch'
+
       - name: Publish to GitHub Packages
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          npm run gh-release-package-swap
           npm publish


### PR DESCRIPTION
If this works, I can probably put together a "dual-publish" workflow on GitHub to handle NPM && GitHub publishing at the same time.