### PR TITLE
Pin action version for @ava-cassiopeia/publish-to-npm-and-github

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
           npm run build
 
       - name: Publish package to GitHub and NPM
-        uses: ava-cassiopeia/publish-to-npm-and-github@17e0f17ee3a5649cd84fb56bec57ccb84c3f8772
+        uses: ava-cassiopeia/publish-to-npm-and-github@1.0.0
         with:
           npm-package-name: 'a-simple-switch'
           github-package-name: '@ava-cassiopeia/a-simple-switch'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a-simple-switch",
-  "version": "0.9.11",
+  "version": "0.9.12",
   "description": "Vanilla JS/CSS Switch UI element",
   "main": "release/commonjs/index.js",
   "files": [


### PR DESCRIPTION
This action is officially working as expected and [has a 1.0 release now](https://github.com/ava-cassiopeia/publish-to-npm-and-github/releases/tag/1.0.0)! This PR then should be the last of the chain of painful tests where we actually pin the version to the latest release.

woo!